### PR TITLE
feat: improve rendering performance by `content-visibility`

### DIFF
--- a/packages/web-components/src/card/card.styles.ts
+++ b/packages/web-components/src/card/card.styles.ts
@@ -22,6 +22,10 @@ export const CardStyles = css`
   :host(:focus-within) {
     --elevation: 8;
   }
+
+  :host * {
+    content-visibility: auto;
+  }
 `.withBehaviors(
   neutralFillCardRestBehavior,
   forcedColorsStylesheetBehavior(


### PR DESCRIPTION
Add the CSS `content-visibility: auto` to fluent-card of web-component. This style will avoid some unnecessary rendering processes when the components are not in the viewport.
It will improve the performance of the page, like some feeds flow or multiple cards grid.

#### Pull request checklist
None

#### Description of changes
Add CSS `content-visibility: auto` to all elements of fluent-card.

#### Focus areas to test
It shouldn't influence any feature or display of components.
